### PR TITLE
Update csvdir.py

### DIFF
--- a/zipline/data/bundles/csvdir.py
+++ b/zipline/data/bundles/csvdir.py
@@ -14,7 +14,7 @@ from zipline.utils.calendars import register_calendar_alias
 from zipline.utils.cli import maybe_show_progress
 
 logger = logbook.Logger(__name__)
-exchanges =['CSVDIR']
+exchanges =['SMART']
 
 
 def csvdir_equities(tframes=['daily'], start=None, end=None):

--- a/zipline/data/bundles/csvdir.py
+++ b/zipline/data/bundles/csvdir.py
@@ -94,7 +94,7 @@ class CSVDIRBundle:
         self.exchanges = {}
         self.assettypes = {}
         self.csvfiles = {}
-        self.exchangeslist=[]
+
 
     def ingest(self, environ, asset_db_writer, minute_bar_writer,
                daily_bar_writer, adjustment_writer, calendar, start_session,
@@ -221,8 +221,8 @@ class CSVDIRBundle:
 
                 yield sid, dfr
                 
-        self.exchangeslist.extend(list(set(self.exchanges.values())))
+        exchanges.extend(list(set(self.exchanges.values())))
 
-self.exchangeslist = list(set(self.exchangeslist))
-for exchange in self.exchangeslist:
+exchanges = list(set(exchanges))
+for exchange in exchanges:
     register_calendar_alias(exchange, "NYSE")


### PR DESCRIPTION
Hi, I adjusted the CSVdir so it can handle different exchanges (as needed for live trading some tickets like GLD, GDX, and to get live data from VIX index on CBOE. Everything works the same if one doesnt put in the exchange in the filename, or the asset type, but if you do the asset get loaded that way and the calendar gets matched to NYSE. Later we might extend this to have other calendar mappings, but for now I map everything to NYSE.